### PR TITLE
Fix for precondition checks on stringList

### DIFF
--- a/SwiftTweaks/Tweak.swift
+++ b/SwiftTweaks/Tweak.swift
@@ -84,8 +84,8 @@ extension Tweak {
 	public static func stringList(_ collectionName: String, _ groupName: String, _ tweakName: String, options: [String], defaultValue: String?=nil) -> Tweak<StringOption> {
 		precondition(!options.isEmpty, "Options list cannot be empty (stringList tweak \"\(tweakName)\")")
 		precondition(
-			defaultValue != nil && options.index(of: defaultValue!) == nil,
-			"The default value of the stringList tweak \"\(tweakName)\" must be in the list of options"
+			defaultValue == nil || (defaultValue != nil && options.index(of: defaultValue!) != nil),
+			"The default value \"\(defaultValue)\" of the stringList tweak \"\(tweakName)\" must be in the list of options \"\(options)\""
 		)
 
 		return Tweak<StringOption>(

--- a/SwiftTweaks/TweakTableCell.swift
+++ b/SwiftTweaks/TweakTableCell.swift
@@ -169,7 +169,7 @@ internal final class TweakTableCell: UITableViewCell {
 
 			let accessoryFrame = colorControlFrame.union(textFrame).union(disclosureArrowFrame)
 			accessory.bounds = accessoryFrame.integral
-		case let .stringList(value: value, defaultValue: defaultValue, options: options):
+		case let .stringList(value: value, defaultValue: _, options: options):
 			segmentedControl.removeAllSegments()
 			for option in options {
 				segmentedControl.insertSegment(


### PR DESCRIPTION
Changed the check to see if the default value is nil, then pass because we will use options[0] for the default. If default is not nil then fixed check if options.index(of:) is not nil.

Also replaced defaultValue with _ in TweakTableCell layout subviews.